### PR TITLE
Translate Persian text in module templates

### DIFF
--- a/module/compare.html
+++ b/module/compare.html
@@ -44,7 +44,7 @@
                         </svg>
 
                     </i>
-                    <span>کالای جدیدی اضافه کنید</span>
+                    <span>Add a new product</span>
                 </a>
             </li>
             <li class="pc__list--null"></li>
@@ -66,7 +66,7 @@
                         </svg>
 
                     </i>
-                    <span>کالای جدیدی اضافه کنید</span>
+                    <span>Add a new product</span>
                 </a>
             </li>
             <li class="pc__list--null"></li>
@@ -87,7 +87,7 @@
                         </svg>
 
                     </i>
-                    <span>کالای جدیدی اضافه کنید</span>
+                    <span>Add a new product</span>
                 </a>
             </li>
             <li class="pc__list--null"></li>
@@ -107,7 +107,7 @@
                         </svg>
 
                     </i>
-                    <span>کالای جدیدی اضافه کنید</span>
+                    <span>Add a new product</span>
                 </a>
             </li>
             {/if}

--- a/module/footer.html
+++ b/module/footer.html
@@ -26,7 +26,7 @@
                     </ul>
                 </div>
                 <div class="col-xs-12 col-sm-9 col-md-5 col-lg-6 col-lg-offset-1">
-                    <h5 class="footerTitle">لینک های دسترسی</h5>
+                    <h5 class="footerTitle">Quick Links</h5>
                     {if="@$loop_menu_bottom_footer"}
                     {$loop_menu_bottom_footer=array_slice($loop_menu_bottom_footer, 0, 1);}
                     {loop="loop_menu_bottom_footer"}
@@ -48,7 +48,7 @@
 
                 </div>
                 <div class="col-xs-12 col-sm-12 col-md-4 col-lg-3">
-                    <h5 class="footerTitle">عضویت در خبرنامه</h5>
+                    <h5 class="footerTitle">Newsletter Subscription</h5>
 
                     <div class="newsletterForm">
                         <div class="form-groups">
@@ -82,7 +82,7 @@
                 <div class="row">
 
                     <div class="col-xs-12 col-sm-8 col-md-8 col-lg-9">
-                        <h5 class="footerTitle">اطلاعات تماس</h5>
+                        <h5 class="footerTitle">Contact Information</h5>
                         <ul class="list-unstyled footerInfo">
                             {if="@$footer.footer_address"}
                             <li>
@@ -137,7 +137,7 @@
                                 </svg>
                                 <a href="tel:{$footer.footer_tell}" class="strClear">
 
-                                    دفتر مرکزی: {$footer.footer_tell}
+                                    Head office: {$footer.footer_tell}
                                 </a>
                             </li>
                             {/if}
@@ -145,7 +145,7 @@
 
                     </div>
                     <div class="col-xs-12 col-sm-4 col-md-4 col-lg-3">
-                        <h5 class="footerTitle">ما را دنبال کنید</h5>
+                        <h5 class="footerTitle">Follow Us</h5>
                         <div class="socialFooter">
                             <div class="socialNetworks">
                                 <ul class="list-unstyled">
@@ -276,7 +276,7 @@
                         {*
                         <div id="ham3d">
                             <a href="https://www.ham3d.co/" class="ham3d"></a>
-                            <p><a href="https://www.ham3d.co/">طراحی سایت</a> و <a href="https://www.ham3d.co/">برنامه نویسی</a>: <a href="https://www.ham3d.co/">حامد پردازش</a></p>
+                            <p><a href="https://www.ham3d.co/">Website design</a> and <a href="https://www.ham3d.co/">programming</a>: <a href="https://www.ham3d.co/">Hamed Processing</a></p>
                         </div>
                         *}
                     </div>

--- a/module/footer_js.html
+++ b/module/footer_js.html
@@ -275,7 +275,7 @@ $(document).ready(function () {
         var popup = L.popup();
         function onMapClick1(e) {
             removeMarkers();
-            popup.setLatLng(e.latlng).setContent("موقعیت انتخابی شما").openOn(map);
+            popup.setLatLng(e.latlng).setContent("Your selected location").openOn(map);
             arr=[{lat:e.latlng.lat,lon:e.latlng.lng,txt:txt}];
             shopwMarkers(arr) ;
             $("#lgmap_"+ids).val(e.latlng.lng);
@@ -298,7 +298,7 @@ $(document).ready(function () {
             $("#lgmap_0").val(position.coords.longitude);
             $("#qgmap_0").val(position.coords.latitude);
             var ell = {lat:position.coords.latitude,lon:position.coords.longitude};
-            popup.setLatLng(ell).setContent("موقعیت انتخابی شما").openOn(map);
+            popup.setLatLng(ell).setContent("Your selected location").openOn(map);
             arr=[{lat:position.coords.latitude,lon:position.coords.longitude,txt:txt}];
             shopwMarkers(arr) ;
         }

--- a/module/header.html
+++ b/module/header.html
@@ -40,7 +40,7 @@
                             fill="white" />
                     </svg>
 
-                    <span>جستجو</span>
+                    <span>Search</span>
                 </a>
             </li>
 
@@ -171,9 +171,9 @@
                     <ul class="list-unstyled">
                         {if="@$loop_menu_top_header"}
                         {loop="loop_menu_top_header"}
-                        {if="@$value.title=='محصولات'"}
+                        {if="@$value.title=='Products'"}
                         <li {if="@$loop_index_product_cat"}class="submenu"{/if}>
-                            <a href="{$value1.url|convert_url}" {if="@$value1.kind == '2'"}target="_blank"{/if}>محصولات</a>
+                            <a href="{$value1.url|convert_url}" {if="@$value1.kind == '2'"}target="_blank"{/if}>Products</a>
                             {if="@$loop_index_product_cat"}
                             <div class="mega_menu" style="display: none;">
                                 <div class="container">

--- a/module/mobile_menu.html
+++ b/module/mobile_menu.html
@@ -10,7 +10,7 @@
             <ul id="mobileMenu">
                 {if="@$loop_menu_top_header"}
                 {loop="loop_menu_top_header"}
-                {if="@$value1.title=='محصولات'"}
+                {if="@$value1.title=='Products'"}
                 <li>
                     <a href="{$value1.url|convert_url}" {if="@$value1.kind == '2'"}target="_blank"{/if}>
                         {$value1.title}

--- a/module/modal.html
+++ b/module/modal.html
@@ -18,7 +18,7 @@
 
 <div class="modal fade" id="searchModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
     <a href="" class="closeSearchModal">
-        بستن
+        Close
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
             <g transform="translate(-182.615 -110.615)">
                 <rect width="1.088" height="27.196" transform="translate(182.615 111.384) rotate(-45)" fill="#fff" />
@@ -32,7 +32,7 @@
                 <div class="searchModal_content">
                     <form action="{$site_url}{$site_lang}/product" id="formsearch" class="form-site-search not_ajax">
                         <div class="searchInModal">
-                            <input type="text" name="" id="advancedSearchInput" placeholder="کلمه یا عبارت مورد نظر خود را وارد کنید"
+                            <input type="text" name="" id="advancedSearchInput" placeholder="Enter your desired word or phrase"
                                 class="search_inp" />
                             <button type="button" class="search_btn">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="33.679"
@@ -61,7 +61,7 @@
         <a aria-label="Close" data-dismiss="modal" class="modal-close closeAdvancedSearch compareModalCloseBtn"></a>
         <div class="searchModal_content">
             <div class="searchBox">
-                <input type="text" class="advancedSearchInput searchBox__inp search_compare" id="searched" placeholder="کالای مورد نظر را برای مقایسه جستجو نمایید...">
+                <input type="text" class="advancedSearchInput searchBox__inp search_compare" id="searched" placeholder="Search for the desired product to compare...">
                 <button type="button" class="searchBox__btn"></button>
                 <div class="advancedSearch compare_search">
                     <div class="row">
@@ -77,14 +77,14 @@
                                                     <div class="compareView">
                                                     </div>
                                                     <img src="{$template_dir}img/compareImage.png"
-                                                        alt="دارک لایت - ۸ سانتی متر" title="دارک لایت - ۸ سانتی متر">
+                                                        alt="Dark Light - 8 centimeters" title="Dark Light - 8 centimeters">
                                                 </a>
                                                 <div class="product__wrapper">
                                                     <a href=""
-                                                        class="product__wrapper--title">دارک لایت - ۸ سانتی متر</a>
+                                                        class="product__wrapper--title">Dark Light - 8 centimeters</a>
                                                   
                                                 </div>
-                                                <a href="" class="btn">مقایسه کنید</a>
+                                                <a href="" class="btn">Compare</a>
                                         
                                             </div>
                                         </li>
@@ -94,14 +94,14 @@
                                                     <div class="compareView">
                                                     </div>
                                                     <img src="{$template_dir}img/compareImage.png"
-                                                        alt="دارک لایت - ۸ سانتی متر" title="دارک لایت - ۸ سانتی متر">
+                                                        alt="Dark Light - 8 centimeters" title="Dark Light - 8 centimeters">
                                                 </a>
                                                 <div class="product__wrapper">
                                                     <a href=""
-                                                        class="product__wrapper--title">دارک لایت - ۸ سانتی متر</a>
+                                                        class="product__wrapper--title">Dark Light - 8 centimeters</a>
                                                    
                                                 </div>
-                                                <a href="" class="btn">مقایسه کنید</a>
+                                                <a href="" class="btn">Compare</a>
                                         
                                             </div>
                                         </li>
@@ -111,14 +111,14 @@
                                                     <div class="compareView">
                                                     </div>
                                                     <img src="{$template_dir}img/compareImage.png"
-                                                        alt="دارک لایت - ۸ سانتی متر" title="دارک لایت - ۸ سانتی متر">
+                                                        alt="Dark Light - 8 centimeters" title="Dark Light - 8 centimeters">
                                                 </a>
                                                 <div class="product__wrapper">
                                                     <a href=""
-                                                        class="product__wrapper--title">دارک لایت - ۸ سانتی متر</a>
+                                                        class="product__wrapper--title">Dark Light - 8 centimeters</a>
                                                   
                                                 </div>
-                                                <a href="" class="btn">مقایسه کنید</a>
+                                                <a href="" class="btn">Compare</a>
                                         
                                             </div>
                                         </li>
@@ -128,14 +128,14 @@
                                                     <div class="compareView">
                                                     </div>
                                                     <img src="{$template_dir}img/compareImage.png"
-                                                        alt="دارک لایت - ۸ سانتی متر" title="دارک لایت - ۸ سانتی متر">
+                                                        alt="Dark Light - 8 centimeters" title="Dark Light - 8 centimeters">
                                                 </a>
                                                 <div class="product__wrapper">
                                                     <a href=""
-                                                        class="product__wrapper--title">دارک لایت - ۸ سانتی متر</a>
+                                                        class="product__wrapper--title">Dark Light - 8 centimeters</a>
                                                   
                                                 </div>
-                                                <a href="" class="btn">مقایسه کنید</a>
+                                                <a href="" class="btn">Compare</a>
                                         
                                             </div>
                                         </li>
@@ -145,14 +145,14 @@
                                                     <div class="compareView">
                                                     </div>
                                                     <img src="{$template_dir}img/compareImage.png"
-                                                        alt="دارک لایت - ۸ سانتی متر" title="دارک لایت - ۸ سانتی متر">
+                                                        alt="Dark Light - 8 centimeters" title="Dark Light - 8 centimeters">
                                                 </a>
                                                 <div class="product__wrapper">
                                                     <a href=""
-                                                        class="product__wrapper--title">دارک لایت - ۸ سانتی متر</a>
+                                                        class="product__wrapper--title">Dark Light - 8 centimeters</a>
                                                   
                                                 </div>
-                                                <a href="" class="btn">مقایسه کنید</a>
+                                                <a href="" class="btn">Compare</a>
                                         
                                             </div>
                                         </li>
@@ -162,14 +162,14 @@
                                                     <div class="compareView">
                                                     </div>
                                                     <img src="{$template_dir}img/compareImage.png"
-                                                        alt="دارک لایت - ۸ سانتی متر" title="دارک لایت - ۸ سانتی متر">
+                                                        alt="Dark Light - 8 centimeters" title="Dark Light - 8 centimeters">
                                                 </a>
                                                 <div class="product__wrapper">
                                                     <a href=""
-                                                        class="product__wrapper--title">دارک لایت - ۸ سانتی متر</a>
+                                                        class="product__wrapper--title">Dark Light - 8 centimeters</a>
                                                  
                                                 </div>
-                                                <a href="" class="btn">مقایسه کنید</a>
+                                                <a href="" class="btn">Compare</a>
                                         
                                             </div>
                                         </li>

--- a/module/price_load.html
+++ b/module/price_load.html
@@ -51,7 +51,7 @@
         <span class="singlePage__price--new"><span>{$p.new_price|num2price}</span>{#touman#}</span>
         <div>
             <span class="singlePage__price--old">{$p.old_price|num2price}</span>
-            <span class="singlePage__price--offer">٪{$p.percent|num2price}</span>
+            <span class="singlePage__price--offer">%{$p.percent|num2price}</span>
         </div>
     </div>
     {else}

--- a/module/product.html
+++ b/module/product.html
@@ -3,11 +3,11 @@
     <div class="chb chbCompare">
         <label>
             {if="@$value.price_id && @$value.num > 0 && @$value.price_active==1"}
-            <input type="checkbox" name="compare" class="compare" title="مقایسه" value="{$value.id}" data-idcomparison="{$value.id}" data-priceid="{$value.price_id}">
+            <input type="checkbox" name="compare" class="compare" title="Compare" value="{$value.id}" data-idcomparison="{$value.id}" data-priceid="{$value.price_id}">
             {else}
-            <input type="checkbox" name="compare" class="compare" title="مقایسه" value="{$value.id}" data-idcomparison="{$value.id}" data-priceid="{$value.id}">
+            <input type="checkbox" name="compare" class="compare" title="Compare" value="{$value.id}" data-idcomparison="{$value.id}" data-priceid="{$value.id}">
             {/if}
-            <span></span>مقایسه
+            <span></span>Compare
             
     </label>
     </div>

--- a/module/proinfo.html
+++ b/module/proinfo.html
@@ -83,8 +83,8 @@ $(document).ready(function() {
                 starOn: 'star-on.png',
                 //starOff: 'icon icon-star icon-empty',
                 //starOn: 'icon icon-star icon-fill',
-                    noRatedMsg: '! بدون امتیاز',
-                    hints: ['بد', 'ضعیف', 'عادی', 'خوب', 'عالی'],
+                    noRatedMsg: 'No rating!',
+                    hints: ['Bad', 'Weak', 'Average', 'Good', 'Excellent'],
                     readOnly: true,
                     score: function() {
                         return $(this).attr('data-score');
@@ -130,8 +130,8 @@ $(function() {
         space:false,
         starOff: 'star-big-off.png',
         starOn: 'star-big-on.png',
-        noRatedMsg: '! بدون امتیاز',
-        hints: ['بد', 'ضعیف', 'عادی', 'خوب', 'عالی'],
+        noRatedMsg: 'No rating!',
+        hints: ['Bad', 'Weak', 'Average', 'Good', 'Excellent'],
         score: function() {
             return $(this).attr('data-score');
         },
@@ -153,20 +153,20 @@ $(function() {
                 success: function( data ) {
                     if ( $.isEmptyObject( data ) ) {
                         $(".basket-modal").modal('show');
-                        $('.basket-modal').find('.modal-title').html('امتیاز دادن');
-                        $('.basket-modal').find('p').html('امتیاز داده شد.');
+                        $('.basket-modal').find('.modal-title').html('Rate this product');
+                        $('.basket-modal').find('p').html('Your rating has been submitted.');
                         $('.basket-modal').find('a.shopping').css({display: 'none', width: '120px'});
                         $('.basket-modal').find('a.checkout').css({display: 'none', width: '120px'});
                     } else if ( data.error == 'no' ) {
                         $(".basket-modal").modal('show');
-                        $('.basket-modal').find('.modal-title').html('امتیاز دادن');
-                        $('.basket-modal').find('p').html('شما قبلا امتیاز داده اید!');
+                        $('.basket-modal').find('.modal-title').html('Rate this product');
+                        $('.basket-modal').find('p').html('You have already rated!');
                         $('.basket-modal').find('a.shopping').css({display: 'none', width: '120px'});
                         $('.basket-modal').find('a.checkout').css({display: 'none', width: '120px'});
                     } else if ( data.user == 'no' ) {
                         $(".basket-modal").modal('show');
-                        $('.basket-modal').find('.modal-title').html('امتیاز دادن');
-                        $('.basket-modal').find('p').html('برای امتیاز دادن باید در سایت عضو شوید.');
+                        $('.basket-modal').find('.modal-title').html('Rate this product');
+                        $('.basket-modal').find('p').html('You must register on the site to rate.');
                         $('.basket-modal').find('a.shopping').css({display: 'none', width: '120px'});
                         $('.basket-modal').find('a.checkout').css({display: 'none', width: '120px'});
                         setTimeout(function(){

--- a/module/schema.html
+++ b/module/schema.html
@@ -60,7 +60,7 @@
     }
     ,
     {
-        "@context": "https://schema.org/", "@type": "Product", "mpn": "{$code}", "url": "{$url}", "name": "{$meta_title_web}", "alternateName": "{$title_english}", "image": "{$image}", "description": "{if="@$description"}{$description}{else}{$title}{/if}", "sku":"تعداد",
+        "@context": "https://schema.org/", "@type": "Product", "mpn": "{$code}", "url": "{$url}", "name": "{$meta_title_web}", "alternateName": "{$title_english}", "image": "{$image}", "description": "{if="@$description"}{$description}{else}{$title}{/if}", "sku":"Quantity",
         
         "offers":[ 
             {


### PR DESCRIPTION
## Summary
- translate visible compare module prompts to English
- update navigation, modal, product, and footer templates to use English labels and placeholders
- convert rating messages, schema metadata, and map popups to English equivalents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc8fc70c4832cbd6b8855fcf82acf